### PR TITLE
Rename, rake task "etherhive" to "hiveway"

### DIFF
--- a/lib/tasks/etherhive.rake
+++ b/lib/tasks/etherhive.rake
@@ -3,7 +3,7 @@
 require 'optparse'
 require 'colorize'
 
-namespace :etherhive do
+namespace :hiveway do
   desc 'Configure the instance for production use'
   task :setup do
     prompt = TTY::Prompt.new


### PR DESCRIPTION

I did that rake task 

```
RAILS_ENV=production bundle exec rake hiveway:make_admin
```

But, `rake aborted!`

Because, rake task namespace is  `:etherhive`

This pull request, rename  `:etherhive` to `:hiveway`

